### PR TITLE
fix layout index category and layout show

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -16,7 +16,7 @@ class CategoryController extends Controller
      */
     public function index()
     {
-        $listCategories = Category::paginate(config('define.category.limit_rows'));
+        $listCategories = Category::with('parentCategories')->withCount('products')->paginate(config('define.category.limit_rows'));
         $data['listCategories'] = $listCategories;
         return view('admin.pages.categories.index', $data);
     }
@@ -80,7 +80,7 @@ class CategoryController extends Controller
      */
     public function show($id)
     {
-        $itemCategory = Category::find($id);
+        $itemCategory = Category::with('parentCategories')->find($id);
         $childCategory = Category::with('categories')->where('parent_id', $id)->get();
         $data['itemCategory'] = $itemCategory;
         $data['childCategory'] = $childCategory;

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -36,4 +36,14 @@ class Category extends Model
     {
         return $this->hasMany('App\Models\Category', 'parent_id', 'id');
     }
+
+    /**
+     * Get the products for the category.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function parentCategories()
+    {
+        return $this->hasMany('App\Models\Category', 'id', 'parent_id');
+    }
 }

--- a/resources/lang/en/category.php
+++ b/resources/lang/en/category.php
@@ -14,6 +14,7 @@ return [
             'updated_at' => 'Updated At',
             'action' => 'Action',
             'child_category' => 'Child Category',
+            'sum_product' => 'Sum Product',
         ],
         'add' => [
             'title' => 'Add Category',
@@ -25,6 +26,9 @@ return [
         ],
         'edit' => [
             'title' => 'Edit Category',
+        ],
+        'show' => [
+            'title' => 'Show Category',
         ],
         'message' => [
             'add' => 'Create New Category Successfull!',

--- a/resources/views/admin/pages/categories/index.blade.php
+++ b/resources/views/admin/pages/categories/index.blade.php
@@ -16,24 +16,32 @@
             <table class="table table-striped jambo_table bulk_action">
               <thead>
                 <tr class="headings">
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.id') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.name') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.parent_id') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.created_at') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.updated_at') }}</th>
-                  <th class="column-title no-link last" style="display: table-cell;"><span class="nobr">{{ __('category.admin.table.action') }}</span>
-                  </th>
+                  <th class="column-title col-md-3">{{ __('category.admin.table.name') }}</th>
+                  <th class="column-title col-md-3">{{ __('category.admin.add.parent_category') }}</th>
+                  <th class="column-title col-md-3">{{ __('category.admin.table.sum_product') }}</th>
+                  <th class="column-title no-link last"><span class="nobr">{{ __('category.admin.table.action') }}</span></th>
                 </tr>
               </thead>
               <tbody>
                 @foreach ($listCategories as $list)
                 <tr class="even pointer">
-                  <td class=" ">{{ $list->id }}</td>
-                  <td><a href="{{ route('admin.categories.show', ['id' => $list->id]) }}">{{ $list->name }}</td>
-                  <td class=" ">{{ $list->parent_id }}</td>
-                  <td class=" ">{{ $list->created_at }}</td>
-                  <td class="a-right a-right ">{{ $list->updated_at }}</td>
-                  <td class="last "><a href="{{ route('admin.categories.edit', ['id' => $list->id] ) }}"><i class="fa fa-edit"></i></a> | <a href=""><i class="fa fa-trash"></i></a>
+                  <td>{{ $list->name }}</td>
+                  <td class=" ">
+                    @foreach ($list->parentCategories as $cat)
+                      {{ $cat->name }}
+                    @endforeach
+                  </td>
+                  <td>{{ $list->products_count }}</td>
+                  <td>
+                    <form class="col-md-4">
+                      <a class="btn btn-primary" href="{{ route('admin.categories.edit', ['id' => $list->id] ) }}"><i class="fa fa-edit"></i></a>
+                    </form>
+                    <form action="" class="col-md-4" method="POST" id="">
+                      <button class="btn btn-danger" type="submit"><i class="fa fa-trash icon-size" ></i></button>
+                    </form>
+                    <form class="col-md-4">
+                      <a class="btn btn-primary" href="{{ route('admin.categories.show', ['id' => $list->id]) }}"><i class="fa fa-eye icon-size" ></i></a>
+                    </form>
                   </td>
                 </tr>
                 @endforeach

--- a/resources/views/admin/pages/categories/show.blade.php
+++ b/resources/views/admin/pages/categories/show.blade.php
@@ -10,7 +10,7 @@
     <div class="col-md-12 col-sm-12 col-xs-12">
       <div class="x_panel">
         <div class="x_title">
-          <h2>{{ __('category.admin.list.title') }}</h2>
+          <h2>{{ __('category.admin.show.title') }}</h2>
           <div class="clearfix"></div>
         </div>
         <div class="x_content">
@@ -18,25 +18,26 @@
             <table class="table table-striped jambo_table bulk_action">
               <thead>
                 <tr class="headings">
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.id') }}</th>
                   <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.name') }}</th>
                   <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.child_category') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.created_at') }}</th>
-                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.table.updated_at') }}</th>
+                  <th class="column-title" style="display: table-cell;">{{ __('category.admin.add.parent_category') }}</th>
                 </tr>
               </thead>
               <tbody>
                 <tr class="even pointer">
-                  <td>{{ $itemCategory->id }}</td>
                   <td>{{ $itemCategory->name }}</td>
                   <td></td>
-                  <td>{{ $itemCategory->created_at }}</td>
-                  <td class="a-right a-right ">{{ $itemCategory->updated_at }}</td>
-                  </td>
+                  <td></td>
                 </tr>
+                @foreach ($itemCategory->parentCategories as $parent)
+                <tr class="even pointer">
+                  <td></td>
+                  <td></td>
+                  <td>{{ $parent->name }}</td>
+                </tr>
+                @endforeach
                 @foreach ($childCategory as $child)
                 <tr class="even pointer">
-                  <td>{{ $child->id }}</td>
                   <td></td>
                   <td id="showChild">
                   {{ $child->name }}
@@ -46,9 +47,7 @@
                     @endforeach
                     </ul>
                   </td>
-                  <td>{{ $child->created_at }}</td>
-                  <td class="a-right a-right ">{{ $child->updated_at }}</td>
-                  </td>
+                  <td></td>
                 </tr>
                 @endforeach
               </tbody>


### PR DESCRIPTION
## Description
fix layout index category and layout show
## Reference Requirements


## Reference Isuees


## Migrations
NO

## Impacted Areas in Application
List general components of the application that this PR will affect:

- 

## SQL query and `explain`
List of all queries and attach the result of each explaining query (in text, screenshot...)

`Query Layout Index`

> explain select count(*) as aggregate from `categories`\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: categories
   partitions: NULL
         type: index
possible_keys: NULL
          key: PRIMARY
      key_len: 4
          ref: NULL
         rows: 33
     filtered: 100.00
        Extra: Using index
1 row in set, 1 warning (0.00 sec)
```

> explain select `categories`.*, (select count(*) from `products` where `categories`.`id` = `products`.`category_id` and `products`.`deleted_at` is null) as `products_count` from `categories` limit 10 offset 0 \G; 

```
*************************** 1. row ***************************
           id: 1
  select_type: PRIMARY
        table: categories
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 33
     filtered: 100.00
        Extra: NULL
*************************** 2. row ***************************
           id: 2
  select_type: DEPENDENT SUBQUERY
        table: products
   partitions: NULL
         type: ref
possible_keys: products_category_id_foreign
          key: products_category_id_foreign
      key_len: 4
          ref: product_tiki.categories.id
         rows: 1
     filtered: 10.00
        Extra: Using where
2 rows in set, 2 warnings (0.00 sec)
```

> explain select * from `categories` where `categories`.`id` in ('', '1')\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: categories
   partitions: NULL
         type: range
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: NULL
         rows: 2
     filtered: 100.00
        Extra: Using where
1 row in set, 1 warning (0.00 sec)
```
`Query layout Show`

> explain select * from `categories` where `categories`.`id` = '1' limit 1\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: categories
   partitions: NULL
         type: const
possible_keys: PRIMARY
          key: PRIMARY
      key_len: 4
          ref: const
         rows: 1
     filtered: 100.00
        Extra: NULL
1 row in set, 1 warning (0.00 sec)
```

> explain select * from `categories` where `categories`.`id` in ('')\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: NULL
   partitions: NULL
         type: NULL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: NULL
     filtered: NULL
        Extra: no matching row in const table
1 row in set, 1 warning (0.00 sec)
```

> explain select * from `categories` where `parent_id` = '1'\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: categories
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 33
     filtered: 10.00
        Extra: Using where
1 row in set, 1 warning (0.00 sec)
```

> explain select * from `categories` where `categories`.`parent_id` in ('5', '7', '8', '9', '10', '13', '14')\G;

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: categories
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 33
     filtered: 50.00
        Extra: Using where
1 row in set, 1 warning (0.00 sec)
```

